### PR TITLE
Add .xlsx icon support.

### DIFF
--- a/public/js/scripts/views.js
+++ b/public/js/scripts/views.js
@@ -217,8 +217,8 @@ v.FileView = Backbone.View.extend({
 		var type = this.model.simpleinfo.filetype;
 		var filearray = [
 			//put the popular ones first
-			"zip", "doc", "pdf","ppt","xls", 
-			"acc", "avi","bmp","c", "cpp", "dmg", "exe", "flv", "gif", "h", "html", 
+			"zip", "doc", "pdf", "ppt", "xls", "xlsx", 
+			"acc", "avi", "bmp","c", "cpp", "dmg", "exe", "flv", "gif", "h", "html", 
 			"ics", "java", "jpg", "key", "mp3", "mid", "mp4", "mpg", "php","png", 
 			"psd", "py", "qt", "rar", "rb", "rtf", "sql", "tiff", "txt", "wav", 
 			"xml"


### PR DESCRIPTION
Untested, but it isn't a earth-shatteringly huge change (and I couldn't figure out how to setup a test environment in Ubuntu (guyz how do i terminal)). Noticed there was a .xlsx icon in the file-type folder, but it isn't used.

(I originally wanted to make it so .docx and .pptx would use the .doc and .ppt icons, but the only way I could see to do so was to insert a conditional specifically for those cases - messy. Easy solution would be to actually add proper icons ;p)
