### PR TITLE
Announcement html support

### DIFF
--- a/javascript/ivle.js
+++ b/javascript/ivle.js
@@ -25,7 +25,7 @@ Ivle.prototype.jsonP_ = function(endpoint, params, success, error) {
     dataType: 'jsonp',
     data: _.extend({
       "APIKey" : Ivle.API_KEY,
-      "Token" : this.token,
+      "AuthToken" : this.token,
       "output" : "json"}, params),
     contentType:"application/x-javascript",
     url: Ivle.BASE_URL + endpoint,
@@ -37,22 +37,22 @@ Ivle.prototype.jsonP_ = function(endpoint, params, success, error) {
 
 
 Ivle.prototype.validate = function(callback) {
-  this.jsonP_('Validate', {}, callback);
+  this.jsonP_('Validate', { "Token": this.token }, callback);
 };
 
 
 Ivle.prototype.getUid = function(callback) {
-  this.jsonP_('UserID_Get', {}, callback);
+  this.jsonP_('UserID_Get', { "Token": this.token }, callback);
 };
 
 
 Ivle.prototype.getUname = function(callback) {
-  this.jsonP_('UserName_Get', {}, callback);
+  this.jsonP_('UserName_Get', { "Token": this.token }, callback);
 };
 
 
 Ivle.prototype.getUname = function(callback) {
-  this.jsonP_('UserEmail_Get', {}, callback);
+  this.jsonP_('UserEmail_Get', { "Token": this.token }, callback);
 };
 
 

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -477,7 +477,7 @@ var AnnouncementView = React.createClass({
           </div>
           <span className='date'>{utils.readabledate(this.props.date)}</span>
         </div>
-      <div className='postbody'>{this.props.contents}</div>
+      <div className='postbody'dangerouslySetInnerHTML={{__html: this.props.contents}} />
       </div>
     );
   }


### PR DESCRIPTION
Hi,

Just passing by as I'm taking CS3245 this sem and I saw your work. I wished I found this sooner instead of dealing with the poor IVLE UI (especially for threads now 😭 ).

So I found out #63 and wanted to correct it first. Actually, I found out that the github version didn't support the current GET params because [Login](https://wiki.nus.edu.sg/display/ivlelapi/Login) is still using `Token` but [Module](https://wiki.nus.edu.sg/display/ivlelapi/Module) and the other ones are now using `AuthToken`. It's reflected on your website, but not on GitHub so I changed them as well here (proposed a similar solution as on your website I guess).

Best regards,
Tim.